### PR TITLE
push on main only

### DIFF
--- a/.github/workflows/linux-cpp-codeql-test.yml
+++ b/.github/workflows/linux-cpp-codeql-test.yml
@@ -3,6 +3,8 @@ name: CPP CodeQL Test
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/linux-cpp-codeql-test.yml
+++ b/.github/workflows/linux-cpp-codeql-test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   cpp-codeql-test:
     name: CPP CodeQL Test
-    runs-on: macos-tracer
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/linux-cpp-codeql-test.yml
+++ b/.github/workflows/linux-cpp-codeql-test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   cpp-codeql-test:
     name: CPP CodeQL Test
-    runs-on: ubuntu-20.04
+    runs-on: macos-tracer
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/linux-csharp-codeql-test.yml
+++ b/.github/workflows/linux-csharp-codeql-test.yml
@@ -3,6 +3,8 @@ name: Csharp CodeQL Test
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/linux-go-codeql-test.yml
+++ b/.github/workflows/linux-go-codeql-test.yml
@@ -3,6 +3,8 @@ name: Go CodeQL Test
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/linux-java-codeql-test.yml
+++ b/.github/workflows/linux-java-codeql-test.yml
@@ -3,6 +3,8 @@ name: Java CodeQL Test
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/linux-javascript-codeql-test.yml
+++ b/.github/workflows/linux-javascript-codeql-test.yml
@@ -3,6 +3,8 @@ name: Javascript CodeQL Test
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/linux-python-codeql-test.yml
+++ b/.github/workflows/linux-python-codeql-test.yml
@@ -3,6 +3,8 @@ name: Python CodeQL Test
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/linux-ruby-codeql-test.yml
+++ b/.github/workflows/linux-ruby-codeql-test.yml
@@ -3,6 +3,8 @@ name: Ruby CodeQL Test
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/linux-swift-codeql-test.yml
+++ b/.github/workflows/linux-swift-codeql-test.yml
@@ -3,6 +3,8 @@ name: Swift CodeQL Test
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
Changed workflow triggers to only run on push to main. 

Otherwise we get multiple workflow triggers on PR updates. 

I'll also add branch protection on `main`